### PR TITLE
MAK-Relic-Tool/Issue-Tracker#39 Hotfix

### DIFF
--- a/src/relic/sga/core/__init__.py
+++ b/src/relic/sga/core/__init__.py
@@ -3,4 +3,4 @@ Shared definitions used by several components of the module
 """
 from relic.sga.core.definitions import Version, MagicWord, StorageType, VerificationType
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"

--- a/src/relic/sga/core/filesystem.py
+++ b/src/relic/sga/core/filesystem.py
@@ -28,6 +28,8 @@ from fs.multifs import MultiFS
 from fs.opener import Opener, registry as fs_registry
 from fs.opener.parse import ParseResult
 from fs.path import split
+from fs.permissions import Permissions
+from fs.subfs import SubFS
 
 from relic.sga.core.definitions import Version, MagicWord, _validate_magic_word
 from relic.sga.core.errors import VersionNotSupportedError
@@ -292,6 +294,15 @@ class _EssenceDriveFS(MemoryFS):
 
     def getessence(self, path: str) -> Info:
         return self.getinfo(path, [ESSENCE_NAMESPACE])
+
+    def makedirs(
+        self,
+        path,  # type: Text
+        permissions=None,  # type: Optional[Permissions]
+        recreate=False,  # type: bool
+    ):  # type: (...) -> SubFS[FS]
+        _path = path.replace("\\", "/")  # Coerce path seperator
+        return super().makedirs(_path, permissions, recreate)
 
 
 class EssenceFS(MultiFS):


### PR DESCRIPTION
Fix makedirs not respecting `\\` seperator.

Closes MAK-Relic-Tool/Issue-Tracker#39 (again), knowing pyfilesystem, this will not be the last time I fix issue 39.