### PR TITLE
SGA Packing Patch

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ relic.cli =
 relic.cli.sga =
     unpack = relic.sga.core.cli:RelicSgaUnpackCli
     pack = relic.sga.core.cli:RelicSgaPackCli
+    repack = relic.sga.core.cli:RelicSgaRepackCli
 
 [options.packages.find]
 where = src

--- a/src/relic/sga/core/__init__.py
+++ b/src/relic/sga/core/__init__.py
@@ -3,4 +3,4 @@ Shared definitions used by several components of the module
 """
 from relic.sga.core.definitions import Version, MagicWord, StorageType, VerificationType
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"

--- a/src/relic/sga/core/cli.py
+++ b/src/relic/sga/core/cli.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 import os.path
 from argparse import ArgumentParser, Namespace
-from typing import Optional
+from typing import Optional, Callable
 
 import fs.copy
 from fs.base import FS
@@ -14,7 +14,7 @@ class RelicSgaCli(CliPluginGroup):
     GROUP = "relic.cli.sga"
 
     def _create_parser(
-            self, command_group: Optional[_SubParsersAction] = None
+        self, command_group: Optional[_SubParsersAction] = None
     ) -> ArgumentParser:
         if command_group is None:
             return ArgumentParser("sga")
@@ -22,13 +22,12 @@ class RelicSgaCli(CliPluginGroup):
             return command_group.add_parser("sga")
 
 
-
-def _arg_exists_err( value ):
+def _arg_exists_err(value: str) -> argparse.ArgumentTypeError:
     return argparse.ArgumentTypeError(f"The given path '{value}' does not exist!")
 
 
-def _get_dir_type_validator(exists:bool):
-    def _dir_type(path: str):
+def _get_dir_type_validator(exists: bool) -> Callable[[str], str]:
+    def _dir_type(path: str) -> str:
         if not os.path.exists(path):
             if exists:
                 raise _arg_exists_err(path)
@@ -43,8 +42,8 @@ def _get_dir_type_validator(exists:bool):
     return _dir_type
 
 
-def _get_file_type_validator(exists:Optional[bool]):
-    def _file_type(path: str):
+def _get_file_type_validator(exists: Optional[bool]) -> Callable[[str], str]:
+    def _file_type(path: str) -> str:
         if not os.path.exists(path):
             if exists:
                 raise _arg_exists_err(path)
@@ -61,7 +60,7 @@ def _get_file_type_validator(exists:Optional[bool]):
 
 class RelicSgaUnpackCli(CliPlugin):
     def _create_parser(
-            self, command_group: Optional[_SubParsersAction] = None
+        self, command_group: Optional[_SubParsersAction] = None
     ) -> ArgumentParser:
         parser: ArgumentParser
         if command_group is None:
@@ -69,8 +68,16 @@ class RelicSgaUnpackCli(CliPlugin):
         else:
             parser = command_group.add_parser("unpack")
 
-        parser.add_argument("src_sga", type=_get_file_type_validator(exists=True), help="Source SGA File")
-        parser.add_argument("out_dir", type=_get_dir_type_validator(exists=False), help="Output Directory")
+        parser.add_argument(
+            "src_sga",
+            type=_get_file_type_validator(exists=True),
+            help="Source SGA File",
+        )
+        parser.add_argument(
+            "out_dir",
+            type=_get_dir_type_validator(exists=False),
+            help="Output Directory",
+        )
 
         return parser
 
@@ -92,7 +99,7 @@ class RelicSgaPackCli(CliPluginGroup):
     GROUP = "relic.cli.sga.pack"
 
     def _create_parser(
-            self, command_group: Optional[_SubParsersAction] = None
+        self, command_group: Optional[_SubParsersAction] = None
     ) -> ArgumentParser:
         parser: ArgumentParser
         if command_group is None:
@@ -111,14 +118,14 @@ class RelicSgaRepackCli(CliPluginGroup):
     GROUP = "relic.cli.sga.repack"
 
     def _create_parser(
-            self, command_group: Optional[_SubParsersAction] = None
+        self, command_group: Optional[_SubParsersAction] = None
     ) -> ArgumentParser:
         parser: ArgumentParser
         desc = "Debug Command; reads and repacks an SGA archive."
         if command_group is None:
             parser = ArgumentParser("repack", description=desc)
         else:
-            parser = command_group.add_parser("repack", description = desc)
+            parser = command_group.add_parser("repack", description=desc)
 
         # pack further delegates to version plugins
 

--- a/src/relic/sga/core/cli.py
+++ b/src/relic/sga/core/cli.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import argparse
+import os.path
 from argparse import ArgumentParser, Namespace
 from typing import Optional
 
@@ -12,7 +14,7 @@ class RelicSgaCli(CliPluginGroup):
     GROUP = "relic.cli.sga"
 
     def _create_parser(
-        self, command_group: Optional[_SubParsersAction] = None
+            self, command_group: Optional[_SubParsersAction] = None
     ) -> ArgumentParser:
         if command_group is None:
             return ArgumentParser("sga")
@@ -20,9 +22,46 @@ class RelicSgaCli(CliPluginGroup):
             return command_group.add_parser("sga")
 
 
+
+def _arg_exists_err( value ):
+    return argparse.ArgumentTypeError(f"The given path '{value}' does not exist!")
+
+
+def _get_dir_type_validator(exists:bool):
+    def _dir_type(path: str):
+        if not os.path.exists(path):
+            if exists:
+                raise _arg_exists_err(path)
+            else:
+                return path
+
+        if os.path.isdir(path):
+            return path
+
+        raise argparse.ArgumentTypeError(f"The given path '{path}' is not a directory!")
+
+    return _dir_type
+
+
+def _get_file_type_validator(exists:Optional[bool]):
+    def _file_type(path: str):
+        if not os.path.exists(path):
+            if exists:
+                raise _arg_exists_err(path)
+            else:
+                return path
+
+        if os.path.isfile(path):
+            return path
+
+        raise argparse.ArgumentTypeError(f"The given path '{path}' is not a file!")
+
+    return _file_type
+
+
 class RelicSgaUnpackCli(CliPlugin):
     def _create_parser(
-        self, command_group: Optional[_SubParsersAction] = None
+            self, command_group: Optional[_SubParsersAction] = None
     ) -> ArgumentParser:
         parser: ArgumentParser
         if command_group is None:
@@ -30,8 +69,8 @@ class RelicSgaUnpackCli(CliPlugin):
         else:
             parser = command_group.add_parser("unpack")
 
-        parser.add_argument("src_sga", type=str, help="Source SGA File")
-        parser.add_argument("out_dir", type=str, help="Output Directory")
+        parser.add_argument("src_sga", type=_get_file_type_validator(exists=True), help="Source SGA File")
+        parser.add_argument("out_dir", type=_get_dir_type_validator(exists=False), help="Output Directory")
 
         return parser
 
@@ -53,13 +92,33 @@ class RelicSgaPackCli(CliPluginGroup):
     GROUP = "relic.cli.sga.pack"
 
     def _create_parser(
-        self, command_group: Optional[_SubParsersAction] = None
+            self, command_group: Optional[_SubParsersAction] = None
     ) -> ArgumentParser:
         parser: ArgumentParser
         if command_group is None:
             parser = ArgumentParser("pack")
         else:
             parser = command_group.add_parser("pack")
+
+        # pack further delegates to version plugins
+
+        return parser
+
+
+class RelicSgaRepackCli(CliPluginGroup):
+    """An alternative to pack which 'repacks' an SGA. Intended for testing purposes."""
+
+    GROUP = "relic.cli.sga.repack"
+
+    def _create_parser(
+            self, command_group: Optional[_SubParsersAction] = None
+    ) -> ArgumentParser:
+        parser: ArgumentParser
+        desc = "Debug Command; reads and repacks an SGA archive."
+        if command_group is None:
+            parser = ArgumentParser("repack", description=desc)
+        else:
+            parser = command_group.add_parser("repack", description = desc)
 
         # pack further delegates to version plugins
 

--- a/src/relic/sga/core/filesystem.py
+++ b/src/relic/sga/core/filesystem.py
@@ -240,7 +240,7 @@ class _EssenceDirEntry(_DirEntry):
 
 
 class _EssenceDriveFS(MemoryFS):
-    def __init__(self, alias: str, name:str) -> None:
+    def __init__(self, alias: str, name: str) -> None:
         super().__init__()
         self.alias = alias
         self.name = name
@@ -290,23 +290,24 @@ class _EssenceDriveFS(MemoryFS):
                 resource_entry.essence.clear()
                 resource_entry.essence.update(essence)
 
-
-
             # if LAZY_NAMESPACE in info and not resource_entry.is_dir:
             #     lazy
 
-    def getinfo(self, path, namespaces=None):  # type: (Text, Optional[Collection[Text]]) -> Info
-        info = super().getinfo(path,namespaces)
+    def getinfo(
+        self, path, namespaces=None
+    ):  # type: (Text, Optional[Collection[Text]]) -> Info
+        info = super().getinfo(path, namespaces)
 
         _path = self.validatepath(path)
-        if _path == "/" and (namespaces is not None and ESSENCE_NAMESPACE in namespaces):
+        if _path == "/" and (
+            namespaces is not None and ESSENCE_NAMESPACE in namespaces
+        ):
             raw_info = info.raw
-            raw_info[ESSENCE_NAMESPACE]["alias"] = self.alias
-            raw_info[ESSENCE_NAMESPACE]["name"] = self.name
+            essence_ns = dict(raw_info[ESSENCE_NAMESPACE])
+            essence_ns["alias"] = self.alias
+            essence_ns["name"] = self.name
             info = Info(raw_info)
         return info
-
-
 
     def getessence(self, path: str) -> Info:
         return self.getinfo(path, [ESSENCE_NAMESPACE])
@@ -340,10 +341,12 @@ class EssenceFS(MultiFS):
     def getessence(self, path: str) -> Info:
         return self.getinfo(path, [ESSENCE_NAMESPACE])
 
-    def create_drive(self, alias: str, name:str) -> _EssenceDriveFS:
+    def create_drive(self, alias: str, name: str) -> _EssenceDriveFS:
         drive = _EssenceDriveFS(alias, name)
         first_drive = len([*self.iterate_fs()]) == 0
-        self.add_fs(alias, drive, write=first_drive) # TODO see if name would work here, using alias because that is what it originally was
+        self.add_fs(
+            alias, drive, write=first_drive
+        )  # TODO see if name would work here, using alias because that is what it originally was
         return drive
 
     def _delegate(self, path):
@@ -355,6 +358,7 @@ class EssenceFS(MultiFS):
             return self.get_fs(parts[0])
 
         return super()._delegate(path)
+
 
 __all__ = [
     "ESSENCE_NAMESPACE",

--- a/src/relic/sga/core/filesystem.py
+++ b/src/relic/sga/core/filesystem.py
@@ -342,7 +342,8 @@ class EssenceFS(MultiFS):
 
     def create_drive(self, alias: str, name:str) -> _EssenceDriveFS:
         drive = _EssenceDriveFS(alias, name)
-        self.add_fs(alias, drive) # TODO see if name would work here, using alias because that is what it originally was
+        first_drive = len([*self.iterate_fs()]) == 0
+        self.add_fs(alias, drive, write=first_drive) # TODO see if name would work here, using alias because that is what it originally was
         return drive
 
     def _delegate(self, path):

--- a/tests/issues/test_issue_39.py
+++ b/tests/issues/test_issue_39.py
@@ -57,13 +57,14 @@ def _pack_fake_osfs(osfs: FS, name: str) -> EssenceFS:
         "essence",
     )
 
-    alias = "test"
+    alias = "data"
+    name = "test data"
     sga_drive = None  # sga.create_drive(alias)
     for path in osfs.walk.files():
         if (
             sga_drive is None
         ):  # Lazily create drive, to avoid empty drives from being created
-            sga_drive = sga.create_drive(alias)
+            sga_drive = sga.create_drive(alias, name)
 
         if "stream" in path:
             storage = StorageType.STREAM_COMPRESS

--- a/tests/issues/test_issue_39.py
+++ b/tests/issues/test_issue_39.py
@@ -44,7 +44,7 @@ _CHUNK_SIZE = 1024 * 1024 * 16  # 16 MiB
 
 
 def _pack_fake_osfs(osfs: FS, name: str) -> EssenceFS:
-    # Create 'SGA'
+    # Create 'SGA' V2
     sga = EssenceFS()
     sga.setmeta(
         {

--- a/tests/issues/test_issue_40.py
+++ b/tests/issues/test_issue_40.py
@@ -1,0 +1,28 @@
+r"""
+TestCases for more explicit errors when providing invalid path arguments.
+https://github.com/MAK-Relic-Tool/Issue-Tracker/issues/40
+"""
+import io
+from collections import Sequence
+from contextlib import redirect_stderr
+
+import pytest
+
+_ARGS = [
+    (["sga","unpack","nonexistant.sga","."],"error: argument src_sga: The given path 'nonexistant.sga' does not exist!" ),
+    (["sga", "unpack", __file__, __file__], rf"error: argument out_dir: The given path '{__file__}' is not a directory!")
+]
+@pytest.mark.parametrize(["args","msg"],_ARGS)
+def test_argparse_error(args:Sequence[str], msg:str):
+    from relic.core.cli import cli_root
+
+    with io.StringIO() as f:
+        with redirect_stderr(f):
+            status = cli_root.run_with(*args)
+            assert status == 2
+        f.seek(0)
+        err = f.read()
+        print (err)
+        assert msg in err
+
+

--- a/tests/issues/test_issue_40.py
+++ b/tests/issues/test_issue_40.py
@@ -3,7 +3,7 @@ TestCases for more explicit errors when providing invalid path arguments.
 https://github.com/MAK-Relic-Tool/Issue-Tracker/issues/40
 """
 import io
-from collections import Sequence
+from typing import Iterable
 from contextlib import redirect_stderr
 
 import pytest
@@ -21,7 +21,7 @@ _ARGS = [
 
 
 @pytest.mark.parametrize(["args", "msg"], _ARGS)
-def test_argparse_error(args: Sequence[str], msg: str):
+def test_argparse_error(args: Iterable[str], msg: str):
     from relic.core.cli import cli_root
 
     with io.StringIO() as f:

--- a/tests/issues/test_issue_40.py
+++ b/tests/issues/test_issue_40.py
@@ -9,11 +9,19 @@ from contextlib import redirect_stderr
 import pytest
 
 _ARGS = [
-    (["sga","unpack","nonexistant.sga","."],"error: argument src_sga: The given path 'nonexistant.sga' does not exist!" ),
-    (["sga", "unpack", __file__, __file__], rf"error: argument out_dir: The given path '{__file__}' is not a directory!")
+    (
+        ["sga", "unpack", "nonexistant.sga", "."],
+        "error: argument src_sga: The given path 'nonexistant.sga' does not exist!",
+    ),
+    (
+        ["sga", "unpack", __file__, __file__],
+        rf"error: argument out_dir: The given path '{__file__}' is not a directory!",
+    ),
 ]
-@pytest.mark.parametrize(["args","msg"],_ARGS)
-def test_argparse_error(args:Sequence[str], msg:str):
+
+
+@pytest.mark.parametrize(["args", "msg"], _ARGS)
+def test_argparse_error(args: Sequence[str], msg: str):
     from relic.core.cli import cli_root
 
     with io.StringIO() as f:
@@ -22,7 +30,5 @@ def test_argparse_error(args:Sequence[str], msg:str):
             assert status == 2
         f.seek(0)
         err = f.read()
-        print (err)
+        print(err)
         assert msg in err
-
-

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -31,7 +31,7 @@ class CommandTests:
             assert status == exit_code
 
 
-_SGA_HELP = ["sga", "-h"], """usage: relic sga [-h] {pack,unpack} ...""", 0
+_SGA_HELP = ["sga", "-h"], """usage: relic sga [-h] {pack,repack,unpack} ...""", 0
 _SGA_PACK_HELP = ["sga", "pack", "-h"], """usage: relic sga pack [-h] {} ...""", 0
 _SGA_UNPACK_HELP = ["sga", "unpack", "-h"], """usage: relic sga unpack [-h]""", 0
 

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -12,13 +12,13 @@ class TestEssenceFS(FSTestCases, unittest.TestCase):
         # EssenceFS shouldn't be writeable by default;
         #   being an emulator for Window's hard drives.
         #       With no 'drive' installed, there's nothing to write to!
-        essence_fs.add_fs("data", _EssenceDriveFS("data"), True)
+        essence_fs.add_fs("data", _EssenceDriveFS("data", "test"), True)
         return essence_fs
 
 
 class TestEssenceDriveFS(FSTestCases, unittest.TestCase):
     def make_fs(self):
-        return _EssenceDriveFS("")
+        return _EssenceDriveFS("data", "test")
 
 
 class TestOpener:


### PR DESCRIPTION
Additions / Fixes:
* New Repack CLI entrypoint
* Properly packs name buffer using '/' instead of '\\'
* Altered name repacking scheme to better match official archives.
  * This likely doesn't affect anything, but is nice when visually comparing archives.
* Allow passing in class instance for Assembler & Disassembler
  * Callbacks were used previously, and should probably now be deprecated
  * Allows each version to manually specify how to assemble/disassemble their packed file system