### PR TITLE
Fix Unix not unpacking files

### DIFF
--- a/src/relic/sga/core/__init__.py
+++ b/src/relic/sga/core/__init__.py
@@ -3,4 +3,4 @@ Shared definitions used by several components of the module
 """
 from relic.sga.core.definitions import Version, MagicWord, StorageType, VerificationType
 
-__version__ = "1.1.2"
+__version__ = "1.1.3"

--- a/src/relic/sga/core/serialization.py
+++ b/src/relic/sga/core/serialization.py
@@ -5,7 +5,6 @@ import typing
 import zlib
 from dataclasses import dataclass
 from io import BytesIO
-from pathlib import PurePath
 from typing import (
     BinaryIO,
     List,
@@ -364,11 +363,11 @@ class FSAssembler(Generic[TFileDef]):
         folder_offset: int,
     ) -> FS:
         raw_folder_name = self.names[folder_def.name_pos]
-        folder_name_as_path = PurePath(raw_folder_name)
+        folder_name_as_path = raw_folder_name.split(
+            "\\"
+        )  # We could gaurd against '/' but because the official relic mod tools crap themselves, we'll crap ourselves too. # TODO, instead of crappign ourselves, maybe produce a decent error? instead of relying on ResourceNotFound?
         folder_name = (
-            folder_name_as_path.parts[-1]
-            if len(folder_name_as_path.parts) > 0
-            else raw_folder_name
+            folder_name_as_path[-1] if len(folder_name_as_path) > 0 else raw_folder_name
         )
 
         folder = parent_dir.makedir(folder_name)

--- a/tests/regressions/test_version_comparisons.py
+++ b/tests/regressions/test_version_comparisons.py
@@ -7,8 +7,10 @@ from relic.sga.core.definitions import Version
 # Chunky versions start at 1
 # Max i've seen is probably 16ish?
 # Minor has a lot mor variety than Chunky; so we test a bit more
-_VERSION_MAJORS = [1, 2, 4, 8, 16]  # arbitrary
-_VERSION_MINORS = [0, 1, 2, 3]  # arbitrary
+_VERSION_MAJORS = range(1,11)  # So far we only go up to V10
+_VERSION_MINORS = [0,1]  # Allegedly CoHO was v4.1 so... we do 0,1
+
+
 _VERSION_ARGS = list(itertools.product(_VERSION_MAJORS, _VERSION_MINORS))
 _VERSIONS = [Version(*a) for a in _VERSION_ARGS]
 _VERSION_IDS = [f"V{v.major}.{v.minor}" for v in _VERSIONS]


### PR DESCRIPTION
`PurePath` is delegating to `PurePosixPath` (duh) on linux, so unpacking fails when trying to parse windows paths and create the required folders.

Could have used `PureWindowsPath` instead of a string `.split` call, but this should also help ensure garbage input raises an error at some point.