### PR TITLE
Version object cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ __pycache__/
 # Ignore Pycharm
 .idea/
 
+# Ignore vscode 
+.vscode/
+
 #Ignore pytest
 .pytest_cache/
 

--- a/src/relic/sga/core/cli.py
+++ b/src/relic/sga/core/cli.py
@@ -284,7 +284,7 @@ class RelicSgaTreeCli(CliPlugin):
             parser = command_group.add_parser("tree", description=desc)
 
         parser.add_argument(
-            "sga",
+            "src_sga",
             type=_get_file_type_validator(exists=True),
             help="SGA File",
         )

--- a/src/relic/sga/core/definitions.py
+++ b/src/relic/sga/core/definitions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import total_ordering
 from enum import Enum
 from typing import Any, Tuple, Iterable, Union, List
 
@@ -12,6 +13,7 @@ MAGIC_WORD = MagicWord(b"_ARCHIVE", name="SGA Magic Word")
 
 
 @dataclass
+@total_ordering
 class Version:
     """A Version object.
 
@@ -44,31 +46,8 @@ class Version:
             other.as_tuple() if isinstance(other, Version) else other
         )
 
-    def __ne__(self, other: object) -> bool:
-        return self.as_tuple() != (
-            other.as_tuple() if isinstance(other, Version) else other
-        )
-
     def __lt__(self, other: Any) -> bool:
         cmp: bool = self.as_tuple() < (
-            other.as_tuple() if isinstance(other, Version) else other
-        )
-        return cmp
-
-    def __gt__(self, other: Any) -> bool:
-        cmp: bool = self.as_tuple() > (
-            other.as_tuple() if isinstance(other, Version) else other
-        )
-        return cmp
-
-    def __le__(self, other: Any) -> bool:
-        cmp: bool = self.as_tuple() <= (
-            other.as_tuple() if isinstance(other, Version) else other
-        )
-        return cmp
-
-    def __ge__(self, other: Any) -> bool:
-        cmp: bool = self.as_tuple() >= (
             other.as_tuple() if isinstance(other, Version) else other
         )
         return cmp


### PR DESCRIPTION
Hi, I looked around and found some things that can be optimized/fixed.

## Version class (definitions.py)
In the Version class, you implemented all logic operators explicitly. That works, but you don't need to do that. If \_\_eq__ or \_\_ne__ is added the opposite one is implicitly created. If you want to create all logic operators you only need to create \_\_eq__ and one other operator(\_\_gt__,\_\_lt__,\_\_le__,\_\_ge__) and add @total_ordering to the class. and all other logic operators are created implicitly by Python. More [here](https://docs.python.org/3/library/functools.html#functools.total_ordering)

## tree command issue (cli.py)
The tree command did not work and threw AttributeError: 'Namespace' object has no attribute 'src_sga'. I found that you had the wrong name for the parser argument. So I fixed it.